### PR TITLE
[BugFix] Check if avatar hash is empty

### DIFF
--- a/config/docker/Dockerfile.app
+++ b/config/docker/Dockerfile.app
@@ -1,10 +1,28 @@
-FROM mzpi/bucklescript:1.7.4
+FROM ocaml/opam2:debian-stable
+
+USER root
+
+# Install OCaml toolchain
+RUN opam update && \
+  opam switch 4.09 && \
+  echo "eval `opam config env`" > /etc/profile.d/opam.sh && \
+  rm -rf /home/opam/opam-repository
+
+RUN rm -rf /var/lib/apt/lists/* && apt-get update
+
+# Install Nodejs toolchain
+RUN (curl -sL https://deb.nodesource.com/setup_10.x | bash -) && \
+  apt-get install -y nodejs --no-install-recommends && \
+  apt-get clean && \
+  rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+RUN npm install -g --unsafe-perm bs-platform@5.0.6
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
       echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
       apt-get update && \
       apt-get install -y yarn --no-install-recommends && \
       apt-get clean && \
-      rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+      sudo rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 WORKDIR /trello.md

--- a/src/bg/markdown.re
+++ b/src/bg/markdown.re
@@ -10,8 +10,13 @@ let quote buffer text => {
 let avatarUrl hash =>
   sprintf "https://trello-avatars.s3.amazonaws.com/%s/30.png" hash;
 
-let avatar member =>
-  sprintf "![%s](%s)" member##username (avatarUrl member##avatarHash);
+let avatar member => {
+  let hash = Js.Null.to_opt member##avatarHash;
+  switch(hash) {
+    | Some hash => sprintf "![%s](%s)" member##username (avatarUrl hash)
+    | None => member##username
+  };
+};
 
 let attachment obj => {
   let url =

--- a/src/bg/member.re
+++ b/src/bg/member.re
@@ -1,6 +1,6 @@
 type t = Js.t {.
   id: string,
-  avatarHash: string,
+  avatarHash: Js.Null.t string,
   username: string
 };
 

--- a/src/bg/member.rei
+++ b/src/bg/member.rei
@@ -1,6 +1,6 @@
 type t = Js.t {.
   id : string,
-  avatarHash: string,
+  avatarHash: Js.Null.t string,
   username: string
 };
 let fetch: Trello.t => string => Js.Promise.t (list t);


### PR DESCRIPTION
## Issue

If there is no avatar hash, the conversion will fail.

## Solution

If the avatar hash is empty, display the member name.

## Test

Tested manually.

## Note

Build on docker failed with following message, so I updated Dockerfile.

```
[WARNING] Running as root is not recommended
yarn run v1.19.1
$ bsb && webpack
/trello.md/node_modules/bs-platform/bin/bsb.exe: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /trello.md/node_modules/bs-platform/bin/bsb.exe)
Error happened when running command /trello.md/node_modules/bs-platform/bin/bsb.exe with args []
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

And updated some libraries.
