### PR TITLE
[Feature]  Convert only a list of specific conditions

### DIFF
--- a/src/bg/markdown.re
+++ b/src/bg/markdown.re
@@ -20,28 +20,37 @@ let attachment obj => {
   sprintf "![%s](%s)" obj##name url;
 };
 
+let regexp = Js.Re.fromString "_$";
+
+let accept name => {
+  let except = Js.Re.test name regexp;
+  not except;
+};
+
 let format xs => {
   let buffer = Buffer.create 0;
   ListLabels.iter xs f::(fun { ListWithCard.list, cards } => {
-    h1 buffer list##name;
-    ListLabels.iter cards f::(fun { ListWithCard.card, members, actions } => {
-      let card_members =
-        members
-        |> List.map avatar
-        |> String.concat " ";
-
-      h2 buffer (sprintf "[:link:](%s) %s %s" card##url card##name card_members);
-      quote buffer card##desc;
-      ListLabels.iter actions f::(fun (action, member) => {
-        quote buffer "----";
-        Option.iter (fun m =>
-                     quote buffer (sprintf "%s %s" (avatar m) action##date)) member;
-        Js.Undefined.iter action##data##text
-          ((fun text => quote buffer text) [@bs]);
-        Js.Undefined.iter action##data##attachment
-          ((fun obj => quote buffer (attachment obj)) [@bs]);
+    if (accept list##name) {
+      h1 buffer list##name;
+      ListLabels.iter cards f::(fun { ListWithCard.card, members, actions } => {
+        let card_members =
+          members
+          |> List.map avatar
+          |> String.concat " ";
+  
+        h2 buffer (sprintf "[:link:](%s) %s %s" card##url card##name card_members);
+        quote buffer card##desc;
+        ListLabels.iter actions f::(fun (action, member) => {
+          quote buffer "----";
+          Option.iter (fun m =>
+                       quote buffer (sprintf "%s %s" (avatar m) action##date)) member;
+          Js.Undefined.iter action##data##text
+            ((fun text => quote buffer text) [@bs]);
+          Js.Undefined.iter action##data##attachment
+            ((fun obj => quote buffer (attachment obj)) [@bs]);
+        })
       })
-    })
+    }
   });
   Buffer.contents buffer;
 }


### PR DESCRIPTION
## Motivation

I don't want to copy unnecessary lists.

## Suggestion

Look at the list name suffix and decide whether to copy.
Using underscore ( _ )

 * Hoge => Accept
 * Hoge_ => Reject

## Implementation

Checking it on formatting markdown  in markdown.re.

## Testing

Tested manually.

![image](https://user-images.githubusercontent.com/1762675/66730594-bb331f80-ee8d-11e9-88aa-1d32545d5963.png)


Output (some text is masked with xxxx)
```markdown
# Foo

## [:link:](https://trello.com/c/xxxxxxxxx/1-hoge) Hoge 

> 

> ----

> ![corocn](https://trello-avatars.s3.amazonaws.com/xxxxxxxxxxxxxxxxxxxxxxxxxxxx/30.png) 2019-10-14T05:19:51.310Z

> Hello
```