### PR TITLE
アバターURLを変更

### DIFF
--- a/src/bg/markdown.re
+++ b/src/bg/markdown.re
@@ -7,13 +7,13 @@ let quote buffer text => {
   Buffer.add_string buffer ("> " ^ s ^ "\n\n")
 };
 
-let avatarUrl hash =>
-  sprintf "https://trello-avatars.s3.amazonaws.com/%s/30.png" hash;
+let avatarUrl id hash =>
+  sprintf "https://trello-members.s3.amazonaws.com/%s/%s/30.png" id hash;
 
 let avatar member => {
   let hash = Js.Null.to_opt member##avatarHash;
   switch(hash) {
-    | Some hash => sprintf "![%s](%s)" member##username (avatarUrl hash)
+    | Some hash => sprintf "![%s](%s)" member##username (avatarUrl member##id hash)
     | None => member##username
   };
 };


### PR DESCRIPTION
## 背景
Trello のアバター URL ルールが2020/5に変更されていました。
参考: https://stackoverflow.com/questions/39526519/how-to-retrieve-user-avatar-from-a-trello-api

Before: `https://trello-avatars.s3.amazonaws.com/{avatarHash}/30.png`
After: `https://trello-members.s3.amazonaws.com/{id}/{avatarHash}/30.png`

## この PR の目的
新しいアバター URL ルールに対応しました。

## 動作確認
手元の環境で本修正マージ版拡張機能を Chrome にインストールし、
Trello -> markdown コピー -> esa に貼り付け を行ったところ
画像を表示することができました。
![preview](https://user-images.githubusercontent.com/54310803/99865835-d5424400-2bef-11eb-844f-dee721f5d3e6.png)